### PR TITLE
allow jvmtop.sh to be called from a symlink

### DIFF
--- a/src/main/wrappers/jvmtop.sh
+++ b/src/main/wrappers/jvmtop.sh
@@ -4,7 +4,7 @@
 #
 # author: Markus Kolb
 # 
-DIR=$( cd $(dirname $0) ; pwd -P )
+DIR=$(dirname "$(readlink -f "$0")")
 
 if [ -z "$JAVA_HOME" ] ; then
         JAVA_HOME=`readlink -f \`which java 2>/dev/null\` 2>/dev/null | \


### PR DESCRIPTION
With this change `jvmtop.sh` can be symlinked in a directory in the `PATH` and called from anywhere.

```bash
$  ls -l /usr/local/bin/jvmtop.sh
lrwxrwxrwx 1 root root 32 Dec 13 21:46 /usr/local/bin/jvmtop.sh -> /opt/jvmtop with space/jvmtop.sh
```
Before the change:
```bash
$ jvmtop.sh
Error: Could not find or load main class com.jvmtop.JvmTop
```

After the change it works, even if the script is a symlink, and if spaces are contained in the path.

Source for the change:
http://stackoverflow.com/questions/59895/getting-the-current-present-working-directory-of-a-bash-script-from-within-the-s#comment54598418_246128