### PR TITLE
adding commadline option to filter packages from profiling

### DIFF
--- a/src/main/java/com/jvmtop/JvmTop.java
+++ b/src/main/java/com/jvmtop/JvmTop.java
@@ -28,6 +28,7 @@ import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
+import java.util.SplittableRandom;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -106,6 +107,9 @@ public class JvmTop
     parser
         .acceptsAll(Arrays.asList(new String[] { "w", "width" }),
             "Width in columns for the console display").withRequiredArg().ofType(Integer.class);
+    parser
+    .acceptsAll(Arrays.asList(new String[] { "f", "filter" }),
+        "packages to be filtered from profiling").withRequiredArg().ofType(String.class);
 
     parser
         .accepts("threadnamewidth",
@@ -145,6 +149,8 @@ public class JvmTop
     Integer iterations = a.has("once") ? 1 : -1;
 
     Integer threadlimit = null;
+    
+    String[] filters = new String[]{};
 
     boolean threadLimitEnabled = true;
 
@@ -178,6 +184,16 @@ public class JvmTop
     if (a.hasArgument("width"))
     {
       width = (Integer) a.valueOf("width");
+    }
+    
+    if (a.hasArgument("filter"))
+    {
+      String filter  = (String) a.valueOf("filter");
+      filters = filter.split(",");
+      for (int i = 0; i < filters.length; i++)
+      {
+        System.out.println("filter: "+filters[i]);
+      }
     }
 
     if (a.hasArgument("threadlimit"))
@@ -219,7 +235,7 @@ public class JvmTop
       {
         if (profileMode)
         {
-          jvmTop.run(new VMProfileView(pid, width));
+          jvmTop.run(new VMProfileView(pid, width, filters));
         }
         else
         {

--- a/src/main/java/com/jvmtop/profiler/CPUSampler.java
+++ b/src/main/java/com/jvmtop/profiler/CPUSampler.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import joptsimple.internal.Strings;
+
 import com.jvmtop.monitor.VMInfo;
 
 /**
@@ -55,13 +57,7 @@ public class CPUSampler
 
 
   //TODO: these exception list should be expanded to the most common 3rd-party library packages
-  private List<String>                       filter        = Arrays
-                                                               .asList(new String[] {
-      "org.eclipse.", "org.apache.", "java.", "sun.", "com.sun.", "javax.",
-      "oracle.", "com.trilead.", "org.junit.", "org.mockito.",
-      "org.hibernate.", "com.ibm.", "com.caucho."
-
-                                                                     });
+  private List<String>                       filter        = new ArrayList<String>();
 
   private ConcurrentMap<Long, Long>          threadCPUTime = new ConcurrentHashMap<Long, Long>();
 
@@ -71,15 +67,29 @@ public class CPUSampler
   private VMInfo                             vmInfo_;
 
   /**
+   * @param filters 
    * @param threadMxBean
    * @throws Exception
    */
-  public CPUSampler(VMInfo vmInfo) throws Exception
+  public CPUSampler(VMInfo vmInfo, String[] filters) throws Exception
   {
     super();
     threadMxBean_ = vmInfo.getThreadMXBean();
     beginCPUTime_ = vmInfo.getProxyClient().getProcessCpuTime();
     vmInfo_ = vmInfo;
+    String[] defaultFilters = new String[] {
+        "org.eclipse.", "org.apache.", "java.", "sun.", "com.sun.", "javax.",
+        "oracle.", "com.trilead.", "org.junit.", "org.mockito.",
+        "org.hibernate.", "com.ibm.", "com.caucho.", "org.mariadb."};
+    for (int i = 0; i < defaultFilters.length; i++)
+    {
+      filter.add(defaultFilters[i]);
+    }
+    for (int i = 0; i < filters.length; i++)
+    {
+      if(!Strings.isNullOrEmpty(filters[i]))
+        filter.add(filters[i]);
+    }
   }
 
   public List<MethodStats> getTop(int limit)

--- a/src/main/java/com/jvmtop/view/VMProfileView.java
+++ b/src/main/java/com/jvmtop/view/VMProfileView.java
@@ -41,13 +41,13 @@ public class VMProfileView extends AbstractConsoleView
 
   private VMInfo     vmInfo_;
 
-  public VMProfileView(int vmid, Integer width) throws Exception
+  public VMProfileView(int vmid, Integer width, String[] filters) throws Exception
   {
     super(width);
     LocalVirtualMachine localVirtualMachine = LocalVirtualMachine
         .getLocalVirtualMachine(vmid);
     vmInfo_ = VMInfo.processNewVM(localVirtualMachine, vmid);
-    cpuSampler_ = new CPUSampler(vmInfo_);
+    cpuSampler_ = new CPUSampler(vmInfo_, filters);
   }
 
   @Override


### PR DESCRIPTION
For example, to filter all _com.fastxml.jackson_ and _sun.rmi_ classes from profiling start profiling with _--filter_ option as following: 
> `jvmtop.sh --profile --filter com.fastxml.jackson.,sun.rmi. <PID>`