### PR TITLE
Specify source encoding as UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <!-- change it to point to your tools.jar from your JDK -->
         <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
         <jdk.version>1.6</jdk.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -91,7 +92,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>  
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Avoids the maven warning and makes the build more robust when building on platforms with other default encodings.